### PR TITLE
Implement Debugger::peek and clean up arg parsing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ext/cxxopts"]
 	path = ext/cxxopts
 	url = https://github.com/jarro2783/cxxopts
+[submodule "ext/span"]
+	path = ext/span
+	url = https://github.com/tcbrindle/span

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ foreach(MODULE ${MODULES})
   add_subdirectory(src/${MODULE})
 endforeach(MODULE)
 
+# Let all modules include span
+foreach(MODULE ${MODULES})
+	target_include_directories(${MODULE} INTERFACE ext/span/include)
+endforeach()
+
 # I don't know why I need to do this here on Windows, but it woks if this is here
 # TODO: Fix this. SFML variables shouldn't be needed outside the video module
 if (WIN32)
@@ -67,12 +72,12 @@ endif()
 # Add the main executable
 add_executable(tvp src/main/main.cpp)
 
+# Add dependencies
+add_subdirectory(ext/cxxopts)
+
 # Link headers and libraries
 target_link_libraries(tvp cxxopts)
 target_link_libraries(tvp ${MODULES})
-
-# Add dependencies
-add_subdirectory(ext/cxxopts)
 
 # If this is not the release build, compile unit tests
 # TODO: This is should be triggered by some other flag, not CMAKE_BUILD_TYPE

--- a/src/cartridge/CMakeLists.txt
+++ b/src/cartridge/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.5.1)
 project(cartridge)
 
 set(SOURCE_FILES
-    src/meta_cartridge.cpp
+    src/cartridge_metadata.cpp
     src/cartridge.cpp
+    src/instruction_parser.cpp
 )
 
 include_directories(${MODULE_INCLUDE_DIRS})
@@ -12,4 +13,5 @@ add_library(${PROJECT_NAME} STATIC ${SOURCE_FILES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/ext/span/include>
 )

--- a/src/cartridge/include/cartridge/cartridge.h
+++ b/src/cartridge/include/cartridge/cartridge.h
@@ -3,12 +3,14 @@
  * Declares the Cartridge class
  */
 
-#include "cartridge/meta_cartridge.h"
+#include "cartridge/cartridge_metadata.h"
 #include "memory/utils.h"
 
 #include "debugger/debugger.fwd.h"
+#include "instruction_parser.h"
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -17,6 +19,9 @@
 
 namespace cartridge {
 
+/**
+ * Holds the game ROM data
+ */
 class Cartridge {
   private:
 	/**
@@ -47,6 +52,14 @@ class Cartridge {
 	 * @param data Byte to write
 	 */
 	void write(Address address, uint8_t data);
+
+	/**
+	 * Peek a number of lines, starting from an address
+	 * @param start_addr Address to begin reading from
+	 * @param lines Number of lines to read
+	 * @return An ordered map of addresses, and parsed lines at those addresses
+	 */
+	map<Address, InstructionLine> peek(Address start_addr, int lines);
 
 	/**
 	 * Displays the cartridge metadata

--- a/src/cartridge/include/cartridge/cartridge_metadata.h
+++ b/src/cartridge/include/cartridge/cartridge_metadata.h
@@ -1,5 +1,5 @@
 /**
- * @file meta_cartridge.h
+ * @file cartridge_metadata.h
  * Declares the CartridgeMetadata class
  */
 

--- a/src/cartridge/include/cartridge/instruction_parser.h
+++ b/src/cartridge/include/cartridge/instruction_parser.h
@@ -1,0 +1,126 @@
+/**
+ * @file instruction_parser.h
+ * Declares the instruction parser, used to read the ROM data as GB assembly.
+ */
+
+#pragma once
+
+#include <array>
+#include <map>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+// Implementation of std::span
+// This is a shim and can be replaced with <span> when we get C++20
+#include <tcb/span.hpp>
+
+#include "memory/utils.h"
+
+using namespace std;
+using tcb::span;
+
+namespace cartridge {
+
+/**
+ * String representation of one instruction mnemonic
+ *
+ * Contains the parsed output from one instruction - the opcode and any
+ * immediate operands. It also contains a handy string representation of
+ * this instruction with the immediate operands interpolated.
+ */
+struct InstructionLine {
+	/**
+	 * Main instruction opcode
+	 */
+	uint8_t opcode;
+
+	/**
+	 * A value that holds an operand (8 or 16 bit) or nothing
+	 */
+	optional<variant<uint8_t, Address>> operand;
+
+	/**
+	 * Instruction mnemonic with the operand values interpolated.
+	 */
+	string interpolated_mnemonic;
+
+	/**
+	 * Length of this instruction in bytes
+	 * length ∈ {1, 2, 3}
+	 */
+	int length;
+};
+
+/**
+ * Given a chunk (span) of ROM data, this generates a set of parsed lines
+ * that contain each instruction with it's opcode and operands
+ */
+class InstructionParser {
+  private:
+	/**
+	 * A span of ROM data to parse
+	 */
+	span<uint8_t> data;
+
+	/**
+	 * Given a slice of a single instruction, parse it and return an
+	 * InstructionLine object. Note that this does not necessarily
+	 * use all 3 bytes that are passed to it. In case of 1 or 2 byte
+	 * instructions, the remaining data is unused.
+	 *
+	 * @param data_slice A span of three bytes to read inst data
+	 * @return The parsed InstructionLine
+	 */
+	InstructionLine parse_line(span<uint8_t, 3> data_slice);
+
+  public:
+	/**
+	 * Construct a new Instruction Parser object, given a span of ROM data
+	 * @param data A span of input data
+	 */
+	InstructionParser(span<uint8_t> data);
+
+	/**
+	 * Get the given number of lines from the currently spanned instructions,
+	 * which contains the raw bytes and interpolated mnemonic string.
+	 *
+	 * This is done by calling get_mnemonic(), and string splitting it to
+	 * determine the required number of bytes for each instruction.
+	 *
+	 * The instructions are indexed by a relative address, where the first
+	 * byte is always assumed to be address 0x0000, so that this class
+	 * functions independently of the real cartridge address. Note that the
+	 * user of this class will need to add the start address to the relative
+	 * address to get the real ROM address of any given instruction.
+	 *
+	 * For example:
+	 *   Given a data slice that contains (hex) [01, ff, 02, 3d, 0e, 44 ...]
+	 *   and input lines = 3, the lines will be parsed as
+	 *
+	 *   Line  Bytes            Mnemonic             Interpolated Mnemonic
+	 *   1.    [01 ff 02]  =>   LD BC, (d16)    =>   "LD BC, (0xFF02)"
+	 *   2.    [3d      ]  =>   DEC A           =>   "DEC A"
+	 *   3.    [0e 44   ]  =>   LD C, d8        =>   "LD C, 0x44"
+	 *
+	 *   Final Answer
+	 *   0x0001 => "LD BC, (0xFF02)"
+	 *   0x0004 => "DEC A"
+	 *   0x0005 => "LD C, 0x44"
+	 *
+	 * NOTE:
+	 *   This is not a disassembler. The starting of the span is assumed to
+	 *   be a valid instruction, the remainder of the data will be parsed with
+	 *   the assumption that it is all instruction data.
+	 *
+	 *   If there is raw byte data in the given chunk that is NOT valid inst
+	 *   data, this method WILL BREAK!
+	 *
+	 * @param lines Number of lines of assembly code to parse
+	 * @returns A list of assembly instruction lines
+	 */
+	map<Address, InstructionLine> get_instruction_lines(int lines = 10);
+};
+
+} // namespace cartridge

--- a/src/cartridge/src/cartridge.cpp
+++ b/src/cartridge/src/cartridge.cpp
@@ -62,6 +62,18 @@ void Cartridge::write(Address address, uint8_t byte) {
 	data[address] = byte;
 }
 
+map<Address, InstructionLine> Cartridge::peek(Address start_addr, int lines) {
+	// This starts the span at the start addr, and ends 3x lines later
+	// TODO: Bounds check this
+	// It's tricky to count the number of lines after the starting point,
+	// since line count can't be determined without looking at the code and
+	// checking the byte count of each instruction.
+	auto data_slice = span<uint8_t>(this->data.data() + start_addr, lines * 3);
+	auto parser = InstructionParser(data_slice);
+
+	return parser.get_instruction_lines(lines);
+}
+
 // Helper to display cartridge metadata
 void Cartridge::display_metadata() {
 	std::cout << std::left << std::setw(25) << "Game Title: " << std::setw(25)

--- a/src/cartridge/src/cartridge_metadata.cpp
+++ b/src/cartridge/src/cartridge_metadata.cpp
@@ -1,9 +1,9 @@
 /**
- * @file meta_cartridge.cpp
+ * @file cartridge_metadata.cpp
  * Defines the CartridgeMetadata class
  */
 
-#include "cartridge/meta_cartridge.h"
+#include "cartridge/cartridge_metadata.h"
 
 #include <string>
 #include <vector>

--- a/src/cartridge/src/instruction_parser.cpp
+++ b/src/cartridge/src/instruction_parser.cpp
@@ -1,0 +1,96 @@
+/**
+ * @file instruction_parser.cpp
+ * Defines the instruction parser class
+ */
+
+#include "cartridge/instruction_parser.h"
+#include "util/helpers.h"
+
+namespace cartridge {
+
+InstructionParser::InstructionParser(span<uint8_t> data) : data(data) {}
+
+// Returns parsed line and instruction length
+InstructionLine InstructionParser::parse_line(span<uint8_t, 3> data_slice) {
+	// String to search for and replace with data values
+	auto static const single_byte_immediates = {"d8", "r8", "a8"};
+	auto static const double_byte_immediates = {"a16", "d16"};
+
+	// Get mnemonic form for current instruction
+	auto &opcode = data_slice[0];
+	auto mnemonic = get_mnemonic(opcode);
+
+	// If there a single byte immediate, this is a two byte instruction
+	for (auto const immediate : single_byte_immediates) {
+		if (mnemonic.find(immediate) != string::npos) {
+			// Find and replace the d8 or r8 with corresponding operand byte
+			auto &operand = data_slice[1];
+			string_replace(mnemonic, immediate, num_to_hex(operand));
+
+			auto line = InstructionLine{opcode, operand, mnemonic, 2};
+			return line;
+		}
+	}
+
+	// If there a double byte immediate, this is a three byte instruction
+	for (auto const immediate : double_byte_immediates) {
+		if (mnemonic.find(immediate) != string::npos) {
+			// Find and replace the d16 or a16 with corresponding double byte
+			// Combine operand bits into 16 bit address (narrowing conversion!)
+			auto &op_high_bits = data_slice[0];
+			auto &op_low_bits = data_slice[1];
+			auto operand =
+			    static_cast<Address>(op_high_bits << 8 | op_low_bits);
+			string_replace(mnemonic, immediate, num_to_hex(operand));
+
+			auto line = InstructionLine{opcode, operand, mnemonic, 3};
+			return line;
+		}
+	}
+
+	// There are no operand strings to be found in the mnemonic => single byte
+	// inst
+	auto line = InstructionLine{opcode, {}, mnemonic, 1};
+	return line;
+}
+
+map<Address, InstructionLine>
+InstructionParser::get_instruction_lines(int lines) {
+	// Overflow check - We index by 16bit Address type => a max of 0xFFFF
+	// (65538) lines
+	if (lines >= 0xFFFF) {
+		throw std::invalid_argument(
+		    "peek supports only a maximum of 65538 lines.");
+	}
+
+	// From the start of our data chunk, begin reading some lines..
+	int current_lines = 0;
+	map<Address, InstructionLine> instruction_lines;
+
+	// Max cap of lines * 3 bytes, only hit if all lines are 3 byte instructions
+	for (int i = 0; i < lines * 3; /* No increment */) {
+
+		// If we've reached the number of lines the caller wants to read, break
+		if (lines == current_lines) {
+			break;
+		}
+
+		// Get a three byte slice of the current instruction and the next two
+		// bytes, and send it off to be parsed. Note that the instruction may
+		// not be three bytes, and the parse_line method will return how many
+		// bytes of the slice the instruction used. The counter is incremented
+		// accordingly.
+		auto current_instruction_slice = span<uint8_t, 3>(&data.data()[i], 3);
+		auto parsed_line = parse_line(current_instruction_slice);
+
+		// Add to answer map
+		instruction_lines[static_cast<Address>(i)] = parsed_line;
+
+		i += parsed_line.length;
+		current_lines++;
+	}
+
+	return instruction_lines;
+}
+
+} // namespace cartridge

--- a/src/debugger/CMakeLists.txt
+++ b/src/debugger/CMakeLists.txt
@@ -11,5 +11,6 @@ add_library(${PROJECT_NAME} STATIC ${SOURCE_FILES})
 include_directories(${MODULE_INCLUDE_DIRS} include)
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/ext/span/include>
 )
 target_link_libraries(${PROJECT_NAME} cxxopts)

--- a/src/debugger/include/debugger/cli_debugger.h
+++ b/src/debugger/include/debugger/cli_debugger.h
@@ -41,12 +41,6 @@ class CliDebugger : public IDebugger {
 	 */
 	bool run_command(int argc, char **argv);
 
-	/**
-	 * @brief Generates corresponding argc and argv for the given command
-	 * @param command: The user input
-	 */
-	std::tuple<int, char **> cmd_string_to_argv(std::string command);
-
 	CliDebugger(std::unique_ptr<DebuggerCore> debugger_core);
 };
 } // namespace debugger

--- a/src/debugger/include/debugger/debugger_core.h
+++ b/src/debugger/include/debugger/debugger_core.h
@@ -115,11 +115,14 @@ class DebuggerCore {
 	virtual void step();
 
 	/**
-	 * @brief Return the next 'x' lines of code
-	 * @param number of lines of code
+	 * @brief Return the given number of lines of code, starting from the
+	 * address
+	 *
+	 * @param address Address to read instructions from
+	 * @param lines Number of lines of code
 	 * @return A map of Instruction Addresses with corresponding mnemonic
 	 */
-	virtual std::map<Address, std::string> peek(uint32_t lines);
+	virtual std::map<Address, InstructionLine> peek(Address address, int lines);
 };
 
 } // namespace debugger

--- a/src/debugger/src/cli_debugger.cpp
+++ b/src/debugger/src/cli_debugger.cpp
@@ -1,4 +1,5 @@
 #include "debugger/cli_debugger.h"
+#include "util/argv_generator.h"
 #include <iostream>
 
 using namespace debugger;
@@ -6,7 +7,7 @@ using namespace std;
 
 CliDebugger::CliDebugger(std::unique_ptr<DebuggerCore> debugger_core)
     : debugger_core(move(debugger_core)),
-      command_parser("tdb", "The tvp Debugger") {
+      command_parser(cxxopts::Options("tdb", "The tvp Debugger")) {
 
 	// clang-format off
 	command_parser.add_options()
@@ -14,17 +15,48 @@ CliDebugger::CliDebugger(std::unique_ptr<DebuggerCore> debugger_core)
 	    ("step", "Execute one System tick")
 	    ("bp-set", "Set a breakpoint", cxxopts::value<string>())
 	    ("bp-remove", "Remove a breakpoint", cxxopts::value<string>())
-	    ("bp_cycles-set", "Set a CPU cycle breakpoint", cxxopts::value<ClockCycles>()->default_value("0"))
-	    ("bp_cycles-remove", "Remove a breakpoint", cxxopts::value<ClockCycles>()->default_value("0"))
-	    ("bp_ticks-set", "Set a breakpoint", cxxopts::value<ClockCycles>()->default_value("0"))
-	    ("bp_ticks-remove", "Remove a breakpoint", cxxopts::value<ClockCycles>()->default_value("0"))
-	    ("peek", "Peek into the next \'x\' lines of the ROM", cxxopts::value<uint32_t>()->default_value("0"))
+	    ("bp-cycles-set", "Set a CPU cycle breakpoint", cxxopts::value<ClockCycles>())
+	    ("bp-cycles-remove", "Remove a breakpoint", cxxopts::value<ClockCycles>())
+	    ("bp-ticks-set", "Set a breakpoint", cxxopts::value<ClockCycles>())
+	    ("bp-ticks-remove", "Remove a breakpoint", cxxopts::value<ClockCycles>())
 	    ("bp-view", "View All Instruction Breakpoints")
-	    ("bp_ticks-view", "View all Tick Breakpoints")
-	    ("bp_cycles-view", "View all CPU Cycle Breakpoints")
-        ("help", "Print this information");
+	    ("bp-ticks-view", "View all Tick Breakpoints")
+	    ("bp-cycles-view", "View all CPU Cycle Breakpoints")
+	    ("help", "Print this information");
 
+	command_parser.add_options("View code")
+	    ("peek", "Peek into the given address in the ROM", cxxopts::value<string>())
+	    ("n,peek-lines", "Number of lines to peek", cxxopts::value<int>()->default_value("10"));
 	// clang-format on
+}
+
+// Helper to get the given argument from the parsed cxxopts result
+template <typename T>
+optional<T> try_get_arg(cxxopts::ParseResult &parsed_args, string arg_name) {
+	if (parsed_args.count(arg_name) == 0) {
+		return {};
+	}
+
+	try {
+		// This will throw if the argument could not be parsed
+		T result = parsed_args[arg_name].as<T>();
+		return result;
+	} catch (cxxopts::OptionParseException &ex) {
+		return {};
+	}
+}
+
+// Helper to check if the command can be parsed, and return the parsed result
+optional<cxxopts::ParseResult>
+try_parse_command(cxxopts::Options &command_parser, int argc, char **argv) {
+	try {
+		auto result = command_parser.parse(argc, argv);
+		return result;
+	} catch (cxxopts::option_not_exists_exception &ex) {
+		return {};
+	} catch (cxxopts::missing_argument_exception &ex) {
+		return {};
+	}
 }
 
 void CliDebugger::tick() {
@@ -34,9 +66,11 @@ void CliDebugger::tick() {
 		cout << "(tdb) ";
 		getline(std::cin, str);
 
-		//  A hack to make CLI parsing compatible with cxxopts.
+		// A hack to make CLI parsing compatible with cxxopts.
 		str = "./tdb --" + str;
-		auto [argc, argv] = cmd_string_to_argv(str);
+
+		auto argv_generator = ArgvGenerator(str);
+		auto [argc, argv] = argv_generator.get();
 
 		status = run_command(argc, argv);
 
@@ -44,117 +78,121 @@ void CliDebugger::tick() {
 }
 
 bool CliDebugger::run_command(int argc, char **argv) {
-	auto parsed_args = command_parser.parse(argc, argv);
-	if (parsed_args["run"].as<bool>()) {
+	auto return_status = true;
+	auto maybe_parsed_args = try_parse_command(command_parser, argc, argv);
+
+	// If the args could not be parsed, exit..
+	if (!maybe_parsed_args) {
+		cout << command_parser.help() << "\n";
+		return return_status;
+	}
+
+	// The args could be parsed, so get result from the std::optional
+	auto parsed_args = maybe_parsed_args.value();
+
+	if (try_get_arg<bool>(parsed_args, "run")) {
 		debugger_core->run();
-		return true;
 	}
-	if (parsed_args["step"].as<bool>()) {
+
+	else if (try_get_arg<bool>(parsed_args, "step")) {
 		debugger_core->step();
-		return true;
 	}
-	if (parsed_args["bp-view"].as<bool>()) {
+
+	else if (try_get_arg<bool>(parsed_args, "bp-view")) {
 		auto instr_bp = debugger_core->get_breakpoints();
 		cout << "The instructions breakpoints are: ";
-		for (auto i : instr_bp) {
+		for (auto const &i : instr_bp) {
 			cout << num_to_hex(i) << " ";
 		}
 		cout << "\n";
-		return true;
 	}
-	if (parsed_args["bp_ticks-view"].as<bool>()) {
+
+	else if (try_get_arg<bool>(parsed_args, "bp-ticks-view")) {
 		auto tick_bp = debugger_core->get_tick_breakpoints();
 		cout << "The tick breakpoints are: ";
-		for (auto i : tick_bp) {
+		for (auto const &i : tick_bp) {
 			cout << i << " ";
 		}
 		cout << "\n";
-		return true;
 	}
-	if (parsed_args["bp_cycles-view"].as<bool>()) {
+
+	else if (try_get_arg<bool>(parsed_args, "bp-cycles-view")) {
 		auto cycles_bp = debugger_core->get_cycle_breakpoints();
 		cout << "The cycle breakpoints are: ";
-		for (auto i : cycles_bp) {
+		for (auto const &i : cycles_bp) {
 			cout << i << " ";
 		}
 		cout << "\n";
-		return true;
 	}
-	if (parsed_args["help"].as<bool>()) {
-		cout << command_parser.help() << "\n";
-		return true;
-	}
-	if (parsed_args["peek"].as<uint32_t>() > 0) {
-		auto code_map = debugger_core->peek(parsed_args["peek"].as<uint32_t>());
-		for (auto i : code_map) {
-			cout << num_to_hex(i.first) << ": " << i.second << "\n";
-		}
-		return true;
-	}
-	if (!parsed_args["bp-set"].as<string>().empty()) {
-		auto code = debugger_core->set_breakpoint(
-		    string_to_address(parsed_args["bp-set"].as<string>()));
-		if (!code)
-			cout << "bp already set!"
-			     << "\n";
-		return code;
-	}
-	if (!parsed_args["bp-remove"].as<string>().empty()) {
-		auto code = debugger_core->remove_breakpoint(
-		    string_to_address(parsed_args["bp-remove"].as<string>()));
-		if (!code)
-			cout << "bp not present!"
-			     << "\n";
-		return code;
-	}
-	if (parsed_args["bp_ticks-set"].as<ClockCycles>() > 0) {
-		auto code = debugger_core->set_tick_breakpoint(
-		    parsed_args["bp_ticks-set"].as<ClockCycles>());
-		if (!code)
-			cout << "bp already set!"
-			     << "\n";
-		return code;
-	}
-	if (parsed_args["bp_ticks-remove"].as<ClockCycles>() > 0) {
-		auto code = debugger_core->remove_tick_breakpoint(
-		    parsed_args["bp_ticks-remove"].as<ClockCycles>());
-		if (!code)
-			cout << "bp not present!"
-			     << "\n";
-		return code;
-	}
-	if (parsed_args["bp_cycles-set"].as<ClockCycles>() > 0) {
-		auto code = debugger_core->set_cycle_breakpoint(
-		    parsed_args["bp_ticks-set"].as<ClockCycles>());
-		if (!code)
-			cout << "bp already set!"
-			     << "\n";
-		return code;
-	}
-	if (parsed_args["bp_cycles-remove"].as<ClockCycles>() > 0) {
-		auto code = debugger_core->remove_cycle_breakpoint(
-		    parsed_args["bp_ticks-remove"].as<ClockCycles>());
-		if (!code)
-			cout << "bp not present!"
-			     << "\n";
-		return code;
-	}
-	return true;
-}
 
-std::tuple<int, char **> CliDebugger::cmd_string_to_argv(std::string command) {
-	std::vector<char *> argv_vec;
-	int argc = 0;
-	char **argv;
-	stringstream string_splitter(command);
-	std::string temp_string;
-	while (string_splitter >> temp_string) {
-		char *arg = new char[temp_string.size() + 1];
-		copy(temp_string.begin(), temp_string.end(), arg);
-		arg[temp_string.length()] = '\0';
-		argv_vec.push_back(arg);
-		argc++;
+	else if (try_get_arg<string>(parsed_args, "peek")) {
+		auto address = string_to_address(parsed_args["peek"].as<string>());
+		auto line_count = parsed_args["peek-lines"].as<int>();
+		auto code_map = debugger_core->peek(address, line_count);
+		for (auto const &[relative_addr, instruction_line] : code_map) {
+			cout << num_to_hex((Address)(address + relative_addr)) << " => "
+			     << instruction_line.interpolated_mnemonic << "\n";
+		}
 	}
-	argv = &argv_vec[0];
-	return std::make_tuple(argc, argv);
+
+	else if (try_get_arg<string>(parsed_args, "bp-set")) {
+		auto breakpoint = string_to_address(parsed_args["bp-set"].as<string>());
+		auto code = debugger_core->set_breakpoint(breakpoint);
+		if (!code)
+			cout << "bp already set!"
+			     << "\n";
+		return_status = code;
+	}
+
+	else if (try_get_arg<string>(parsed_args, "bp-set")) {
+		auto breakpoint = parsed_args["bp-remove"].as<string>();
+		auto code =
+		    debugger_core->remove_breakpoint(string_to_address(breakpoint));
+		if (!code)
+			cout << "bp not present!"
+			     << "\n";
+		return_status = code;
+	}
+
+	else if (try_get_arg<ClockCycles>(parsed_args, "bp-ticks-set")) {
+		auto breakpoint = parsed_args["bp-ticks-set"].as<ClockCycles>();
+		auto code = debugger_core->set_tick_breakpoint(breakpoint);
+		if (!code)
+			cout << "bp already set!"
+			     << "\n";
+		return_status = code;
+	}
+
+	else if (try_get_arg<ClockCycles>(parsed_args, "bp-ticks-remove")) {
+		auto breakpoint = parsed_args["bp-ticks-set"].as<ClockCycles>();
+		auto code = debugger_core->remove_tick_breakpoint(breakpoint);
+		if (!code)
+			cout << "bp not present!"
+			     << "\n";
+		return_status = code;
+	}
+
+	else if (try_get_arg<ClockCycles>(parsed_args, "bp-ticks-set")) {
+		auto breakpoint = parsed_args["bp-ticks-set"].as<ClockCycles>();
+		auto code = debugger_core->set_cycle_breakpoint(breakpoint);
+		if (!code)
+			cout << "bp already set!"
+			     << "\n";
+		return_status = code;
+	}
+
+	else if (try_get_arg<ClockCycles>(parsed_args, "bp-ticks-remove")) {
+		auto breakpoint = parsed_args["bp-ticks-remove"].as<ClockCycles>();
+		auto code = debugger_core->remove_cycle_breakpoint(breakpoint);
+		if (!code)
+			cout << "bp not present!"
+			     << "\n";
+		return_status = code;
+	}
+
+	else {
+		cout << command_parser.help() << "\n";
+	}
+
+	return return_status;
 }

--- a/src/debugger/src/debugger_core.cpp
+++ b/src/debugger/src/debugger_core.cpp
@@ -91,10 +91,12 @@ std::unordered_set<ClockCycles> DebuggerCore::get_tick_breakpoints() {
 }
 
 void DebuggerCore::run() {
+	// Clear current break and continue execution
 	if (is_breaking) {
 		is_breaking = false;
 		tick();
 	}
+
 	bool is_breakpoint_hit;
 	bool is_ticks_breakpoint_hit;
 	bool is_cycles_breakpoint_hit;
@@ -110,16 +112,15 @@ void DebuggerCore::run() {
 		tick();
 	} while (!is_breakpoint_hit && !is_ticks_breakpoint_hit &&
 	         !is_cycles_breakpoint_hit);
+
 	is_breaking = true;
 }
 
 void DebuggerCore::step() { tick(); }
 
-std::map<Address, std::string> DebuggerCore::peek(uint32_t lines) {
-	auto pc_contents = gameboy->cpu->pc->get();
-	std::map<Address, std::string> code_map;
-	code_map.insert({0, "Peek Not Implemented!"});
-	return code_map;
+std::map<Address, InstructionLine> DebuggerCore::peek(Address address,
+                                                      int lines) {
+	return gameboy->cartridge->peek(address, lines);
 }
 
 } // namespace debugger

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -4,7 +4,7 @@ project(util)
 set(SOURCE_FILES
     src/log.cpp
     src/helpers.cpp
-)
+    src/argv_generator.cpp)
 
 include_directories(${MODULE_INCLUDE_DIRS})
 

--- a/src/util/include/util/argv_generator.h
+++ b/src/util/include/util/argv_generator.h
@@ -1,0 +1,63 @@
+/**
+ * @file argv_generator.h
+ * Declares the ArgvGenerator class
+ */
+
+#pragma once
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+using namespace std;
+
+/**
+ * Converts a string command into a (argc, argv) pair
+ */
+class ArgvGenerator {
+  private:
+	/**
+	 * Argc - Number of args
+	 */
+	int argc;
+
+	/**
+	 * Argv - List of char*s with the split command
+	 */
+	char **argv;
+
+  public:
+	/**
+	 * Constructs argc and argv from the given string
+	 * @param input Command to parse
+	 */
+	ArgvGenerator(string command);
+
+	/**
+	 * Returns argc and argv
+	 * @return Tuple with argc and argv
+	 */
+	tuple<int, char **> get();
+
+	/**
+	 * Deletes resources
+	 */
+	~ArgvGenerator();
+
+	// The following are not strictly required, but must be defined as good
+	// practice to comply with the Rule of 5
+
+	/**
+	 * Copy constructor
+	 */
+	ArgvGenerator(const ArgvGenerator &other);
+
+	/**
+	 * Copy assignment operator
+	 */
+	ArgvGenerator &operator=(const ArgvGenerator &other);
+
+	// No move constructors here
+	ArgvGenerator(ArgvGenerator &&other) = delete;
+	ArgvGenerator &operator=(ArgvGenerator &&other) = delete;
+};

--- a/src/util/include/util/helpers.h
+++ b/src/util/include/util/helpers.h
@@ -16,5 +16,8 @@
 template <typename T> std::string num_to_hex(T i);
 Address string_to_address(std::string num);
 
+bool string_replace(std::string &str, const std::string &from,
+                    const std::string &to);
+
 std::string get_mnemonic(uint8_t opcode);
 std::string get_cb_mnemonic(uint8_t opcode);

--- a/src/util/src/argv_generator.cpp
+++ b/src/util/src/argv_generator.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file argv_generator.cpp
+ * Defines the ArgvGenerator class
+ */
+
+#include "util/argv_generator.h"
+
+#include <cstring>
+#include <iostream>
+#include <sstream>
+
+ArgvGenerator::ArgvGenerator(string command) {
+	std::vector<string> argv_vec;
+
+	// Split command by spaces
+	stringstream string_splitter(command);
+	string temp_string;
+
+	while (string_splitter >> temp_string) {
+		argv_vec.push_back(temp_string);
+	}
+
+	// Argc = Number of strings in split command
+	this->argc = argv_vec.size();
+
+	// Convert each string into a null-terminated char*
+	this->argv = new char *[this->argc];
+	for (int i = 0; i < argv_vec.size(); ++i) {
+		const string &arg_string = argv_vec[i];
+
+		// Generate char* from string
+		char *arg = new char[arg_string.size() + 1];
+		copy(arg_string.begin(), arg_string.end(), arg);
+		arg[arg_string.length()] = '\0';
+
+		// Set ptr in argv
+		this->argv[i] = arg;
+	}
+}
+
+tuple<int, char **> ArgvGenerator::get() { return {argc, argv}; }
+
+ArgvGenerator::~ArgvGenerator() {
+	// Delete each string in argv array
+	while (--argc != 0) {
+		delete[] argv[argc];
+	}
+
+	// Delete main array
+	delete[] argv;
+}
+
+ArgvGenerator::ArgvGenerator(const ArgvGenerator &other) : argc(other.argc) {
+	// Allocate mem and copy argv
+	argv = new char *[argc];
+	for (int i = 0; i < argc; ++i) {
+		char *arg = new char[strlen(other.argv[i])];
+		strcpy(arg, other.argv[i]);
+
+		argv[i] = arg;
+	}
+}
+
+ArgvGenerator &ArgvGenerator::operator=(const ArgvGenerator &other) {
+	// Ensure this is not a self-assignment
+	if (&other == this) {
+		// Clean up the existing contents
+		while (--argc != 0) {
+			delete[] argv[argc];
+		}
+
+		delete[] argv;
+		argv = nullptr;
+
+		// Copy new contents
+		argv = new char *[argc];
+		for (int i = 0; i < argc; ++i) {
+			char *arg = new char[strlen(other.argv[i])];
+			strcpy(arg, other.argv[i]);
+
+			argv[i] = arg;
+		}
+	}
+
+	return *this;
+}

--- a/src/util/src/helpers.cpp
+++ b/src/util/src/helpers.cpp
@@ -31,6 +31,15 @@ Address string_to_address(string num) {
 	return strtoul(num.c_str(), nullptr, 16);
 }
 
+bool string_replace(std::string &str, const std::string &from,
+                    const std::string &to) {
+	auto start_pos = str.find(from);
+	if (start_pos == std::string::npos)
+		return false;
+	str.replace(start_pos, from.length(), to);
+	return true;
+}
+
 string get_mnemonic(uint8_t opcode) {
 	static const auto opcode_mnemonic = unordered_map<uint8_t, string>{
 	    {0x0, "NOP"},          {0x1, "LD BC, d16"},    {0x2, "LD (BC), A"},

--- a/src/video/include/video/video.h
+++ b/src/video/include/video/video.h
@@ -4,7 +4,7 @@
  */
 #pragma once
 
-#include "cartridge/meta_cartridge.h"
+#include "cartridge/cartridge_metadata.h"
 #include "controller/controller_interface.h"
 #include "gpu/utils.h"
 #include "video/video_interface.h"


### PR DESCRIPTION
Implement `peek` method in Debugger
 - Clean up cxxopts arg parsing logic
 - Change `peek` interface to accept a number of lines to display with `-n`
 - Move `argv` parsing logic to memory managed class
 - Add instruction parser class to generate human readable mnemonics with interpolated immediate values for `peek`

This PR also adds https://github.com/tcbrindle/span as a submodule dependency. This serves as a shim for `std::span` since we do not have C++20 support yet (spans are great!)